### PR TITLE
Enhance launcher page with static params and async params handling

### DIFF
--- a/app/downloads/launcher/[launcher]/page.tsx
+++ b/app/downloads/launcher/[launcher]/page.tsx
@@ -1,11 +1,40 @@
 import { LauncherDownloadPage } from "@/components/LauncherDownloadPage";
 import { launcherRepos } from "@/lib/launcherMeta";
+import { redirect } from "next/navigation";
 
-export default async function Page({ params }: { params: { launcher: string } }) {
-  const { launcher: key } = params as { launcher: string };
-  const meta = launcherRepos.find(r => r.key === key);
-  if (!meta) return <div>未知的启动器</div>;
+// 静态参数生成（优化路由预渲染）
+export async function generateStaticParams() {
+  return launcherRepos.map((item) => ({
+    launcher: item.key,
+  }));
+}
 
+// 核心页面逻辑（无调试代码）
+export default async function Page({ params }: { params: Promise<{ launcher: string }> }) {
+  // 解析 Promise 类型的 params（Next.js 15+ 核心要求）
+  const resolvedParams = await params;
+  const key = (resolvedParams?.launcher || "").trim();
+
+  // 参数为空则重定向到启动器列表页
+  if (!key) {
+    redirect("/downloads/launcher");
+  }
+
+  // 匹配启动器元数据
+  const meta = launcherRepos.find((item) => item.key === key);
+  
+  // 未知启动器处理
+  if (!meta) {
+    return (
+      <div style={{ padding: "20px", textAlign: "center" }}>
+        <h2>未知的启动器</h2>
+        <p>你访问的启动器「{key}」不存在</p>
+        <p><a href="/downloads/launcher" style={{ color: "#0070f3" }}>返回启动器列表</a></p>
+      </div>
+    );
+  }
+
+  // 正常渲染下载页面
   return (
     <LauncherDownloadPage
       owner={meta.owner}


### PR DESCRIPTION
Added static parameter generation for launcher routes and updated page logic to:
1. Handle Promise-type `params` (Next.js 15+ breaking change) by unwrapping with `await`
2. Add empty parameter validation with automatic redirection to launcher list
3. Improve error handling for unknown launcher keys with user-friendly prompts

### Key Fixes
- Resolved "unknown launcher" issue caused by unparsed async params
- Ensured all launcher paths (e.g., `/downloads/launcher/hmcl-pe`) work correctly
- Non-breaking change: only modifies `[launcher]/page.tsx` with no impact on other features

### Testing
- Verified `/downloads/launcher/hmcl-pe` renders correct launcher metadata
- Confirmed empty/invalid params redirect to launcher list page
- Tested unknown launcher keys show friendly error messages (no crashes)